### PR TITLE
feat k8s: Custom secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ spec:
 The controller will notice this and, assuming you have a matching hosted zone, create a certificate
 and store it as a secret named `www-yourdomain-com-tls`.
 
+You can override the name of the secret by specifying an annotation called `acme/secretName`.
+
 The certificate secret will contain four files named `certificate.pem`, `chain.pem`, `key.pem` and
 `fullchain.pem`.
 You can [mount these][] into whatever application you use to terminate TLS.

--- a/src/main/java/in/tazj/k8s/letsencrypt/Main.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/Main.java
@@ -8,7 +8,7 @@ import in.tazj.k8s.letsencrypt.acme.CertificateRequestHandler;
 import in.tazj.k8s.letsencrypt.acme.CloudDnsResponder;
 import in.tazj.k8s.letsencrypt.acme.DnsResponder;
 import in.tazj.k8s.letsencrypt.acme.Route53Responder;
-import in.tazj.k8s.letsencrypt.kubernetes.CertificateManager;
+import in.tazj.k8s.letsencrypt.kubernetes.SecretManager;
 import in.tazj.k8s.letsencrypt.kubernetes.KeyPairManager;
 import in.tazj.k8s.letsencrypt.kubernetes.NamespaceManager;
 import in.tazj.k8s.letsencrypt.util.EnvironmentalConfiguration.Configuration;
@@ -31,7 +31,7 @@ public class Main {
   public static void main(String[] args) {
     val config = loadConfiguration();
     val dnsResponder = getCorrectDnsResponder(config);
-    val certificateManager = new CertificateManager(client);
+    val certificateManager = new SecretManager(client);
     val keyPairManager = KeyPairManager.with(client);
     val requestHandler =
         new CertificateRequestHandler(config.getAcmeUrl(), keyPairManager, dnsResponder);

--- a/src/main/java/in/tazj/k8s/letsencrypt/kubernetes/NamespaceManager.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/kubernetes/NamespaceManager.java
@@ -19,16 +19,16 @@ import lombok.val;
 @Slf4j
 public class NamespaceManager implements Watcher<Namespace> {
   final private KubernetesClient client;
-  final private CertificateManager certificateManager;
+  final private SecretManager secretManager;
   final private CertificateRequestHandler requestHandler;
 
   final private ConcurrentMap<String, Thread> namespaceThreadMap = new ConcurrentHashMap<>();
 
   public NamespaceManager(KubernetesClient client,
-                          CertificateManager certificateManager,
+                          SecretManager secretManager,
                           CertificateRequestHandler requestHandler) {
     this.client = client;
-    this.certificateManager = certificateManager;
+    this.secretManager = secretManager;
     this.requestHandler = requestHandler;
   }
 
@@ -51,7 +51,7 @@ public class NamespaceManager implements Watcher<Namespace> {
     val name = namespace.getMetadata().getName();
     if (!namespaceThreadMap.containsKey(name)) {
       log.info("Starting reconciliation loop for namespace {}", name);
-      val serviceManager = new ServiceManager(name, certificateManager, requestHandler);
+      val serviceManager = new ServiceManager(name, secretManager, requestHandler);
       val loop = new ReconciliationLoop(name, serviceManager);
       val thread = new Thread(loop);
       namespaceThreadMap.put(name, thread);

--- a/src/main/java/in/tazj/k8s/letsencrypt/model/CertificateRequest.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/model/CertificateRequest.java
@@ -1,0 +1,20 @@
+package in.tazj.k8s.letsencrypt.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * A request for a signed certificate based upon service annotations.
+ */
+@Value
+@Builder
+public class CertificateRequest {
+  /** The name of the Kubernetes secret to store the certificate in. */
+  String secretName;
+
+  /** The certificate subject name. */
+  String certificateName;
+
+  /** Whether the certificate needs to be renewed. */
+  Boolean renew;
+}

--- a/src/main/java/in/tazj/k8s/letsencrypt/model/Constants.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/model/Constants.java
@@ -7,5 +7,6 @@ final public class Constants {
   final public static String REQUEST_ANNOTATION = "acme/certificate";
   final public static String EXPIRY_ANNOTATION = "acme/expiryDate";
   final public static String ACME_CA_ANNOTATION = "acme/ca";
+  final public static String ACME_SECRET_NAME_ANNOTATION = "acme/secretName";
   final public static String SYSTEM_NAMESPACE = "kube-system";
 }

--- a/src/test/java/in/tazj/k8s/letsencrypt/kubernetes/ServiceManagerTest.java
+++ b/src/test/java/in/tazj/k8s/letsencrypt/kubernetes/ServiceManagerTest.java
@@ -1,0 +1,135 @@
+package in.tazj.k8s.letsencrypt.kubernetes;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+import in.tazj.k8s.letsencrypt.acme.CertificateRequestHandler;
+import in.tazj.k8s.letsencrypt.model.CertificateRequest;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import lombok.val;
+
+import static in.tazj.k8s.letsencrypt.model.Constants.ACME_SECRET_NAME_ANNOTATION;
+import static in.tazj.k8s.letsencrypt.model.Constants.EXPIRY_ANNOTATION;
+import static in.tazj.k8s.letsencrypt.model.Constants.REQUEST_ANNOTATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+public class ServiceManagerTest {
+  private ServiceManager serviceManager = null;
+  final private String EXISTING_CERT = "existing-k8s-io-tls";
+  final private String RENEWAL_CERT = "renewal-k8s-io-tls";
+  final private String CUSTOM_NAME = "customSecretName";
+
+  @Before
+  public void setup() {
+    val secretManager = getMockedSecretManager();
+    val requestHandler = Mockito.mock(CertificateRequestHandler.class);
+
+    serviceManager = new ServiceManager("default", secretManager, requestHandler);
+  }
+
+  private SecretManager getMockedSecretManager() {
+    val existingSecret = prepareExistingSecret();
+    val renewalSecret = prepareRenewalSecret();
+
+    val secretManager = Mockito.mock(SecretManager.class);
+    when(secretManager.getSecret(anyString(), anyString())).thenReturn(Optional.empty());
+    when(secretManager.getSecret(eq("default"), eq(EXISTING_CERT))).thenReturn(existingSecret);
+    when(secretManager.getSecret(eq("default"), eq(RENEWAL_CERT))).thenReturn(renewalSecret);
+    return secretManager;
+  }
+
+  /** Prepare a plain, mocked secret for an existing certificate. */
+  private Optional<Secret> prepareExistingSecret() {
+    val secretMeta = Mockito.mock(ObjectMeta.class);
+    when(secretMeta.getName()).thenReturn(EXISTING_CERT);
+
+    val secret = Mockito.mock(Secret.class);
+    when(secret.getMetadata()).thenReturn(secretMeta);
+
+    return Optional.of(secret);
+  }
+
+  /** Prepare a mocked secret for an expired certificate. */
+  private Optional<Secret> prepareRenewalSecret() {
+    val expiryDate = LocalDate.now().minusDays(1);
+    val annotations = ImmutableMap.of(EXPIRY_ANNOTATION, expiryDate.toString());
+    val secretMeta = Mockito.mock(ObjectMeta.class);
+    when(secretMeta.getName()).thenReturn(RENEWAL_CERT);
+    when(secretMeta.getAnnotations()).thenReturn(annotations);
+
+    val secret = Mockito.mock(Secret.class);
+    when(secret.getMetadata()).thenReturn(secretMeta);
+
+    return Optional.of(secret);
+  }
+
+  @Test
+  public void testNormalCertificateRequest() {
+    val testDomain = "test.k8s.io";
+    val annotations = ImmutableMap.of(REQUEST_ANNOTATION, testDomain);
+    val request = createTestRequest(annotations);
+    val expectedSecret = "test-k8s-io-tls";
+
+    assertTrue("Service manager builds a request", request.isPresent());
+    assertFalse("Request is not a renewal", request.get().getRenew());
+    assertEquals("Request secret name matches", expectedSecret, request.get().getSecretName());
+    assertEquals("Request domain name matches", testDomain, request.get().getCertificateName());
+  }
+
+  @Test
+  public void testExistingCertificateRequest() {
+    val testDomain = "existing.k8s.io";
+    val annotations = ImmutableMap.of(REQUEST_ANNOTATION, testDomain);
+    val request = createTestRequest(annotations);
+
+    assertFalse("No certificate is requested", request.isPresent());
+  }
+
+  @Test
+  public void testCertificateRenewalRequest() {
+    val testDomain = "renewal.k8s.io";
+    val annotations = ImmutableMap.of(REQUEST_ANNOTATION, testDomain);
+    val request = createTestRequest(annotations);
+
+    assertTrue("A certificate is requested", request.isPresent());
+    assertTrue("Certificate request is renewal", request.get().getRenew());
+    assertEquals("Secret name matches", RENEWAL_CERT, request.get().getSecretName());
+  }
+
+  @Test
+  public void testCustomSecretName() {
+    val testDomain = "test.k8s.io";
+    val annotations = ImmutableMap.of(
+        REQUEST_ANNOTATION, testDomain,
+        ACME_SECRET_NAME_ANNOTATION, CUSTOM_NAME);
+    val request = createTestRequest(annotations);
+
+    assertTrue("A certificate is requested", request.isPresent());
+    assertFalse("Certificate is not a renewal", request.get().getRenew());
+    assertEquals("Certificate secret name is custom", CUSTOM_NAME, request.get().getSecretName());
+    assertEquals("Certificate domain name matches", testDomain, request.get().getCertificateName());
+  }
+
+  private Optional<CertificateRequest> createTestRequest (Map<String, String> annotations) {
+    val testMetadata = Mockito.mock(ObjectMeta.class);
+    when(testMetadata.getAnnotations()).thenReturn(annotations);
+    when(testMetadata.getName()).thenReturn("testService");
+    val testService = Mockito.mock(Service.class);
+    when(testService.getMetadata()).thenReturn(testMetadata);
+    return serviceManager.prepareCertificateRequest(testService);
+  }
+}


### PR DESCRIPTION
Fixes #23

This implements support for specifying the desired k8s secret in an
annotation called 'acme/secretName'.

In addition this features some major refactoring:

* CertificateManager is renamed to SecretManager (as it manages k8s
  secrets). Static functions related to secrets have been moved here.
* The flow in ServiceManager has been changed to first construct a new
  object of type CertificateRequest which specifies desired parameters
  of the certificate & secret to be created. Afterwards the request is
  executed.
* Lots of minor changes & new tests.