### PR TITLE
feat acme: Add support for SAN certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,25 @@ metadata:
     acme/certificate: www.yourdomain.com
 spec:
   type: LoadBalancer
-  selector:
-    app: my-app
-  ports:
-    - port: 443
-      name: https
+[...]
 ```
 
 The controller will notice this and, assuming you have a matching hosted zone, create a certificate
 and store it as a secret named `www-yourdomain-com-tls`.
 
 You can override the name of the secret by specifying an annotation called `acme/secretName`.
+
+You may specify multiple domains to include in a certificate as a JSON array. This requires
+setting the `acme/secretName` annotation. For example:
+
+```
+[...]
+metadata:
+  annotations:
+    acme/certificate: '["yourdomain.com", "www.yourdomaian.com"]'
+    acme/secretName: mydomain-certificate
+[...]
+```
 
 The certificate secret will contain four files named `certificate.pem`, `chain.pem`, `key.pem` and
 `fullchain.pem`.

--- a/src/main/java/in/tazj/k8s/letsencrypt/model/CertificateRequest.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/model/CertificateRequest.java
@@ -1,5 +1,7 @@
 package in.tazj.k8s.letsencrypt.model;
 
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Value;
 
@@ -13,7 +15,7 @@ public class CertificateRequest {
   String secretName;
 
   /** The certificate subject name. */
-  String certificateName;
+  List<String> domains;
 
   /** Whether the certificate needs to be renewed. */
   Boolean renew;

--- a/src/main/java/in/tazj/k8s/letsencrypt/model/Constants.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/model/Constants.java
@@ -7,6 +7,6 @@ final public class Constants {
   final public static String REQUEST_ANNOTATION = "acme/certificate";
   final public static String EXPIRY_ANNOTATION = "acme/expiryDate";
   final public static String ACME_CA_ANNOTATION = "acme/ca";
-  final public static String ACME_SECRET_NAME_ANNOTATION = "acme/secretName";
+  final public static String SECRET_NAME_ANNOTATION = "acme/secretName";
   final public static String SYSTEM_NAMESPACE = "kube-system";
 }

--- a/src/test/java/in/tazj/k8s/letsencrypt/kubernetes/ServiceManagerTest.java
+++ b/src/test/java/in/tazj/k8s/letsencrypt/kubernetes/ServiceManagerTest.java
@@ -17,11 +17,13 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import lombok.val;
 
-import static in.tazj.k8s.letsencrypt.model.Constants.ACME_SECRET_NAME_ANNOTATION;
+import static in.tazj.k8s.letsencrypt.model.Constants.SECRET_NAME_ANNOTATION;
 import static in.tazj.k8s.letsencrypt.model.Constants.EXPIRY_ANNOTATION;
 import static in.tazj.k8s.letsencrypt.model.Constants.REQUEST_ANNOTATION;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -87,7 +89,8 @@ public class ServiceManagerTest {
     assertTrue("Service manager builds a request", request.isPresent());
     assertFalse("Request is not a renewal", request.get().getRenew());
     assertEquals("Request secret name matches", expectedSecret, request.get().getSecretName());
-    assertEquals("Request domain name matches", testDomain, request.get().getCertificateName());
+    assertEquals("One domain is included", 1, request.get().getDomains().size());
+    assertEquals("Request domain name matches", testDomain, request.get().getDomains().get(0));
   }
 
   @Test
@@ -115,13 +118,29 @@ public class ServiceManagerTest {
     val testDomain = "test.k8s.io";
     val annotations = ImmutableMap.of(
         REQUEST_ANNOTATION, testDomain,
-        ACME_SECRET_NAME_ANNOTATION, CUSTOM_NAME);
+        SECRET_NAME_ANNOTATION, CUSTOM_NAME);
     val request = createTestRequest(annotations);
 
     assertTrue("A certificate is requested", request.isPresent());
     assertFalse("Certificate is not a renewal", request.get().getRenew());
     assertEquals("Certificate secret name is custom", CUSTOM_NAME, request.get().getSecretName());
-    assertEquals("Certificate domain name matches", testDomain, request.get().getCertificateName());
+    assertEquals("One domain is included", 1, request.get().getDomains().size());
+    assertEquals("Certificate domain name matches", testDomain, request.get().getDomains().get(0));
+  }
+
+  @Test
+  public void testMultipleDomainRequest() {
+    val testDomains = "[\"test1.k8s.io\", \"test2.k8s.io\"]";
+    val annotations = ImmutableMap.of(
+        REQUEST_ANNOTATION, testDomains,
+        SECRET_NAME_ANNOTATION, "testSecret");
+    val request = createTestRequest(annotations);
+
+    assertTrue("A certificate is requested", request.isPresent());
+    assertFalse("Certificate is not a renewal", request.get().getRenew());
+    assertEquals("Two domains are included", 2, request.get().getDomains().size());
+    assertThat("Included domains match", request.get().getDomains(),
+        hasItems("test1.k8s.io", "test2.k8s.io"));
   }
 
   private Optional<CertificateRequest> createTestRequest (Map<String, String> annotations) {


### PR DESCRIPTION
Add support for requesting a certificate for multiple domains at the
same time (SAN certificate).

This is implemented via some additional syntax for the current request
annotation on k8s services.

If a service is a JSON array (checked by comparing the first character
to '[') it is decoded into a list of domains.

If multiple domains are specified the `acme/secretName` annotation MUST
be set to specify the name of the resulting secret.

Fixes #21
Fixes #22
Fixes #17