### PR TITLE
feat acme: Allow Secret filenames to be configured via envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The certificate secret will contain four files named `certificate.pem`, `chain.p
 `fullchain.pem`.
 You can [mount these][] into whatever application you use to terminate TLS.
 
+If required, you can configure these file names via the environment variables,
+`CERTIFICATE_FILENAME`, `CHAIN_FILENAME`, `KEY_FILENAME`, `FULLCHAIN_FILENAME`.
+
 The secret will always be created in the same namespace as your service. Removing the annotation
 will **never** remove a secret.
 

--- a/src/main/java/in/tazj/k8s/letsencrypt/Main.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/Main.java
@@ -34,7 +34,7 @@ public class Main {
     val certificateManager = new SecretManager(client);
     val keyPairManager = KeyPairManager.with(client);
     val requestHandler =
-        new CertificateRequestHandler(config.getAcmeUrl(), keyPairManager, dnsResponder);
+        new CertificateRequestHandler(config.getAcmeUrl(), config.getSecretFilenames(), keyPairManager, dnsResponder);
     val namespaceManager = new NamespaceManager(client, certificateManager, requestHandler);
 
     /* Add all currently existing services to namespace manager */

--- a/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
@@ -20,6 +20,7 @@ import org.shredzone.acme4j.util.KeyPairUtils;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.Map;
 
 import in.tazj.k8s.letsencrypt.kubernetes.KeyPairManager;
 import in.tazj.k8s.letsencrypt.model.CertificateResponse;
@@ -39,11 +40,13 @@ public class CertificateRequestHandler {
   final private String acmeServer;
   final private KeyPairManager keyPairManager;
   final private DnsResponder dnsResponder;
+  final private Map<String, String> secretFilenames;
 
-  public CertificateRequestHandler(String acmeServer, KeyPairManager keyPairManager, DnsResponder dnsResponder) {
+  public CertificateRequestHandler(String acmeServer, Map<String, String> secretFilenames, KeyPairManager keyPairManager, DnsResponder dnsResponder) {
     this.acmeServer = acmeServer;
     this.keyPairManager = keyPairManager;
     this.dnsResponder = dnsResponder;
+    this.secretFilenames = secretFilenames;
   }
 
   public CertificateResponse requestCertificate(List<String> domains) {
@@ -113,10 +116,10 @@ public class CertificateRequestHandler {
     KeyPairUtils.writeKeyPair(domainKeyPair, keyWriter);
 
     val certificateFiles = ImmutableMap.of(
-        "certificate.pem", base64EncodeWriter(certWriter),
-        "chain.pem", base64EncodeWriter(chainWriter),
-        "key.pem", base64EncodeWriter(keyWriter),
-        "fullchain.pem", base64EncodeWriter(certWriter, chainWriter));
+        secretFilenames.get("certificate"), base64EncodeWriter(certWriter),
+        secretFilenames.get("chain"), base64EncodeWriter(chainWriter),
+        secretFilenames.get("key"), base64EncodeWriter(keyWriter),
+        secretFilenames.get("fullchain"), base64EncodeWriter(certWriter, chainWriter));
 
     return new CertificateResponse(domains, certificateFiles,
         downloadedCertificate.getNotAfter(), acmeServer);

--- a/src/main/java/in/tazj/k8s/letsencrypt/util/EnvironmentalConfiguration.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/util/EnvironmentalConfiguration.java
@@ -1,5 +1,7 @@
 package in.tazj.k8s.letsencrypt.util;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 
 import in.tazj.k8s.letsencrypt.util.DetectCloudPlatform.CloudPlatform;
@@ -17,6 +19,7 @@ public class EnvironmentalConfiguration {
   public static class Configuration {
     CloudPlatform cloudPlatform;
     String acmeUrl;
+    Map<String, String> secretFilenames;
   }
 
   public static Configuration loadConfiguration() {
@@ -24,8 +27,9 @@ public class EnvironmentalConfiguration {
     val acmeUrl =
         environment.getOrDefault("ACME_URL", "https://acme-v01.api.letsencrypt.org/directory");
     val cloudPlatform = getOrDetectCloudPlatform(environment);
+    val secretFilenames = getSecretFilenames(environment);
 
-    return new Configuration(cloudPlatform, acmeUrl);
+    return new Configuration(cloudPlatform, acmeUrl, secretFilenames);
   }
 
   private static CloudPlatform getOrDetectCloudPlatform(Map<String, String> environment) {
@@ -41,5 +45,13 @@ public class EnvironmentalConfiguration {
     }
 
     return detectCloudPlatform();
+  }
+
+  private static ImmutableMap getSecretFilenames(Map<String, String> environment) {
+    return ImmutableMap.of(
+      "certificate", environment.getOrDefault("CERTIFICATE_FILENAME", "certificate.pem"),
+      "chain", environment.getOrDefault("CHAIN_FILENAME", "chain.pem"),
+      "key", environment.getOrDefault("KEY_FILENAME", "key.pem"),
+      "fullchain", environment.getOrDefault("FULLCHAIN_FILENAME", "fullchain.pem"));
   }
 }


### PR DESCRIPTION
This allows integration with Ingress types that expect
particular filenames from TLS secrets. E.g GCLB.

Fixes #33 

