### PR TITLE
Re-use previously completed authorizations if they are still valid

### DIFF
--- a/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
@@ -75,6 +75,11 @@ public class CertificateRequestHandler {
   private void authorizeDomain(Registration registration, String domain) {
     try {
       val authorization = getAuthorization(registration, domain);
+
+      if (authorization.getStatus().equals(Status.VALID)) {
+        return;
+      }
+
       val challengeTuple = prepareDnsChallenge(authorization);
       completeChallenge(challengeTuple._1());
       challengeTuple._2().run();

--- a/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
@@ -77,8 +77,11 @@ public class CertificateRequestHandler {
       val authorization = getAuthorization(registration, domain);
 
       if (authorization.getStatus().equals(Status.VALID)) {
+        log.info("Authorization for {} still valid, not issuing new challenge", domain);
         return;
       }
+
+      log.info("Issuing new challenge for {}", domain);
 
       val challengeTuple = prepareDnsChallenge(authorization);
       completeChallenge(challengeTuple._1());
@@ -159,6 +162,8 @@ public class CertificateRequestHandler {
       log.error("Challenge {} failed", challenge.getLocation());
       throw new LetsencryptException("Failed due to invalid challenge");
     }
+
+    log.info("Challenge {} completed", challenge.getLocation());
   }
 
   /**

--- a/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
+++ b/src/main/java/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.java
@@ -28,6 +28,7 @@ import in.tazj.k8s.letsencrypt.util.DnsRecordObserver;
 import in.tazj.k8s.letsencrypt.util.LetsencryptException;
 import javaslang.Tuple;
 import javaslang.Tuple2;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
@@ -37,19 +38,13 @@ import lombok.val;
  * Requests certificates from a specified ACME server.
  */
 @Slf4j
+@RequiredArgsConstructor
 public class CertificateRequestHandler {
   final private BaseEncoding base64 = BaseEncoding.base64();
   final private String acmeServer;
+  final private Map<String, String> secretFilenames;
   final private KeyPairManager keyPairManager;
   final private DnsResponder dnsResponder;
-  final private Map<String, String> secretFilenames;
-
-  public CertificateRequestHandler(String acmeServer, Map<String, String> secretFilenames, KeyPairManager keyPairManager, DnsResponder dnsResponder) {
-    this.acmeServer = acmeServer;
-    this.keyPairManager = keyPairManager;
-    this.dnsResponder = dnsResponder;
-    this.secretFilenames = secretFilenames;
-  }
 
   public CertificateResponse requestCertificate(List<String> domains) {
     final Registration registration = getRegistration();


### PR DESCRIPTION
This allows us to re-use previously completed challenges that are still valid
for the account key.

In practice this will significantly reduce the time it takes to re-provision
certificates with only minor changes to the SAN list.

Fixes #52
