### PR TITLE
Ignore Route53 private zones during response zone selection

### DIFF
--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/Route53Responder.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/Route53Responder.kt
@@ -68,6 +68,9 @@ class Route53Responder(val route53: AmazonRoute53) : DnsResponder {
         val fqdnRecord = determineFqdnRecord(record)
         // Attempt to find the correct hosted zone by matching the longest matching suffix.
         val matchingZone = route53.listHostedZones().hostedZones
+                // Filter out private zones to prevent the controller from writing into the wrong zone in a split-brain
+                // DNS setup.
+                .filter { !it.config.isPrivateZone }
                 .filter { fqdnRecord.endsWith(it.name) }
                 .reduce { acc, zone ->
                     if (zone.name.length > acc.name.length) {

--- a/src/test/kotlin/in/tazj/k8s/letsencrypt/acme/Route53ResponderTest.kt
+++ b/src/test/kotlin/in/tazj/k8s/letsencrypt/acme/Route53ResponderTest.kt
@@ -2,6 +2,7 @@ package `in`.tazj.k8s.letsencrypt.acme
 
 import com.amazonaws.services.route53.AmazonRoute53Client
 import com.amazonaws.services.route53.model.HostedZone
+import com.amazonaws.services.route53.model.HostedZoneConfig
 import com.amazonaws.services.route53.model.ListHostedZonesResult
 import com.google.common.collect.ImmutableList
 import com.nhaarman.mockito_kotlin.doReturn
@@ -13,9 +14,12 @@ class Route53ResponderTest {
     @Test
     fun correctHostedZoneIsFound() {
         val testList = ImmutableList.of(
-                HostedZone("incorrect-1", "tazj.in.", ""),
-                HostedZone("correct", "test.tazj.in.", ""),
+                HostedZone("incorrect-1", "tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(false)),
+                HostedZone("correct", "test.tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(false)),
                 HostedZone("incorrect-2", "other.tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(false))
         )
 
         val client: AmazonRoute53Client = mock {
@@ -28,5 +32,30 @@ class Route53ResponderTest {
 
         Assert.assertTrue("A hosted zone is found", result.isDefined())
         Assert.assertEquals("The selected hosted zone is correct", "correct", result.get().id)
+    }
+
+    @Test
+    fun correctPublicHostedZoneIsFound() {
+        val testList = ImmutableList.of(
+                HostedZone("incorrect-1", "tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(true)),
+                HostedZone("private", "test.tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(true)),
+                HostedZone("public", "test.tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(false)),
+                HostedZone("incorrect-2", "other.tazj.in.", "")
+                        .withConfig(HostedZoneConfig().withPrivateZone(true))
+        )
+
+        val client: AmazonRoute53Client = mock {
+            on { listHostedZones() } doReturn (ListHostedZonesResult().withHostedZones(testList))
+        }
+
+        val responder = Route53Responder(client)
+        val testRecord = "_acme-challenge.some.test.tazj.in"
+        val result = responder.findHostedZone(testRecord)
+
+        Assert.assertTrue("A hosted zone is found", result.isDefined())
+        Assert.assertEquals("The selected hosted zone is correct", "public", result.get().id)
     }
 }


### PR DESCRIPTION
See commit messages, thanks to @itomaldonado for pointing this out in #61!

This closes #62 as an alternative fix.