### PR TITLE
fix acme: Correctly construct Java runnable

### DIFF
--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.kt
@@ -177,9 +177,9 @@ class CertificateRequestHandler(
         val observer = DnsRecordObserver(challengeRecord, rootZone, dns01Challenge.digest)
         observer.observeDns()
 
-        val cleanup: Runnable = {
+        val cleanup: Runnable = Runnable {
             dnsResponder.removeChallengeRecord(challengeRecord, dns01Challenge.digest)
-        } as Runnable
+        }
 
         return Pair(dns01Challenge, cleanup)
     }


### PR DESCRIPTION
Construct a Java Runnable using the provided constructor from the
Kotlin standard library instead of casting a Lambda (which, it turns
out, doesn't work!)

This fixes #63