### PR TITLE
feat k8s: React to domains being removed from requests

### DIFF
--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/kubernetes/SecretManager.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/kubernetes/SecretManager.kt
@@ -114,7 +114,7 @@ class SecretManager(val client: KubernetesClient) {
                     .map {
                         val type = object : TypeToken<List<String>>() {}.type
                         val secretDomains: List<String> = gson.fromJson(it, type)
-                        !secretDomains.containsAll(domains)
+                        (secretDomains.size != domains.size) || !secretDomains.containsAll(domains)
                     }
                     .getOrElse {
                         log.warn("acme/certificate annotation missing on secret {}!", secret.metadata.name)

--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/kubernetes/ServiceManager.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/kubernetes/ServiceManager.kt
@@ -121,7 +121,7 @@ class ServiceManager(
     }
 
     /**
-     * Checks if a given service resource is requesting a Letsencrypt certificate.
+     * Checks if a given service resource is requesting a Let's Encrypt certificate.
      */
     private fun isCertificateRequest(service: Service): Boolean {
         val annotations = service.metadata.annotations


### PR DESCRIPTION
This changes the renewal check to consider whether a domain has been
removed from the certificate list and causes the secret to be
re-provisioned.

This makes it possible for users to remove specific domains from a
certificate without having to recreate the entire secret.

This fixes #55