### PR TITLE
fix acme: Prevent registrations from being fetched in parallel

### DIFF
--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.kt
@@ -185,6 +185,7 @@ class CertificateRequestHandler(
         return Pair(dns01Challenge, cleanup)
     }
 
+    @Synchronized
     private fun getRegistration(): Registration {
         val session = Session(acmeServer, keyPairManager.keyPair)
         var registration: Registration


### PR DESCRIPTION
If several different certificate requests are executed at the same time on a
*new* Let's Encrypt registration a race condition may cause some of the threads
attempting to sign the subscriber agreement to fail.

This commit addresses the issue by marking the getRegistration() method as
@Synchronized, which will simply block other requesting threads until one
registration has been completed.

This fixes #74