### PR TITLE
fix(responders): Prevent reduce() call on empty collections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ services:
   - docker
 before_install:
   - docker --version
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
     dependencies {
         classpath(kotlinModule("gradle-plugin"))
-        classpath("com.bmuschko:gradle-docker-plugin:3.0.9")
+        classpath("com.bmuschko:gradle-docker-plugin:3.2.2")
         classpath("com.github.ben-manes:gradle-versions-plugin:0.15.0")
     }
 }

--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CloudDnsResponder.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CloudDnsResponder.kt
@@ -92,7 +92,13 @@ class CloudDnsResponder(private val dns: Dns) : DnsResponder {
      * Determine the most specific matching zone from available Cloud DNS zones.
      */
     fun findMatchingZone(recordName: String): Option<Zone> {
-        return fetchMatchingZones(recordName)
+        val zones = fetchMatchingZones(recordName)
+
+        if (zones.isEmpty()) {
+            return Option.None
+        }
+
+        return zones
                 .reduce { acc, zone ->
                     if (zone.dnsName.length > acc.dnsName.length) {
                         zone

--- a/src/test/kotlin/in/tazj/k8s/letsencrypt/acme/CloudDnsResponderTest.kt
+++ b/src/test/kotlin/in/tazj/k8s/letsencrypt/acme/CloudDnsResponderTest.kt
@@ -35,6 +35,25 @@ class CloudDnsResponderTest {
         Assert.assertEquals("Correct zone is found", "correct", result.get().name)
     }
 
+    @Test
+    fun testNoZonesAvailable() {
+        val iterator = emptyList<Zone>().iterator()
+        val page: Page<Zone> = mock {
+            on { iterateAll() } doReturn (iterator)
+        }
+
+        val dns: Dns = mock {
+            on { listZones() } doReturn (page)
+        }
+
+        val responder = CloudDnsResponder(dns)
+        val testRecord = "_acme-challenge.some.test.tazj.in"
+
+        val result = responder.findMatchingZone(testRecord)
+
+        Assert.assertTrue("No zone is returned", result.isEmpty())
+    }
+
     private fun zoneOf(name: String, dnsName: String): Zone {
         return mock {
             on { getName() } doReturn (name)

--- a/src/test/kotlin/in/tazj/k8s/letsencrypt/acme/Route53ResponderTest.kt
+++ b/src/test/kotlin/in/tazj/k8s/letsencrypt/acme/Route53ResponderTest.kt
@@ -58,4 +58,18 @@ class Route53ResponderTest {
         Assert.assertTrue("A hosted zone is found", result.isDefined())
         Assert.assertEquals("The selected hosted zone is correct", "public", result.get().id)
     }
+
+    @Test
+    fun testNoZonesAvailable() {
+        val testList = emptyList<HostedZone>()
+        val client: AmazonRoute53Client = mock {
+            on { listHostedZones() } doReturn (ListHostedZonesResult().withHostedZones(testList))
+        }
+
+        val responder = Route53Responder(client)
+        val testRecord = "_acme-challenge.some.test.tazj.in"
+        val result = responder.findHostedZone(testRecord)
+
+        Assert.assertTrue("No hosted zone is found", result.isEmpty())
+    }
 }


### PR DESCRIPTION
Adds a check for empty collections before reducing lists to avoid an
exception.

This fixes #81