### PR TITLE
When a challenge fails, include more details in the log.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,8 +55,8 @@ dependencies {
         // Prevent AWS SDK from dragging in unwanted (unstructured) logging
         exclude(group = "commons-logging")
     }
-    compile("org.shredzone.acme4j", "acme4j-client", "0.10")
-    compile("org.shredzone.acme4j", "acme4j-utils", "0.10")
+    compile("org.shredzone.acme4j", "acme4j-client", "1.0")
+    compile("org.shredzone.acme4j", "acme4j-utils", "1.0")
     compile("dnsjava", "dnsjava", "2.1.8")
     compile("com.google.cloud", "google-cloud-dns", "0.8.0")
     compile("org.funktionale", "funktionale-option", "1.1")

--- a/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.kt
+++ b/src/main/kotlin/in/tazj/k8s/letsencrypt/acme/CertificateRequestHandler.kt
@@ -149,7 +149,8 @@ class CertificateRequestHandler(
         }
 
         if (challenge.status == Status.INVALID) {
-            log.error("Challenge {} failed", challenge.location)
+            log.error("Challenge {} failed: {}:'{}'", challenge.location, challenge.error.type,
+                    challenge.error.detail)
             throw LetsencryptException("Failed due to invalid challenge")
         }
 


### PR DESCRIPTION
Bump the acme4j to 1.0. This now exposes extra error details, which we can log.
Helps with issues like #87.